### PR TITLE
Map WorkloadGroup Template field properly

### DIFF
--- a/pkg/networking/v1alpha3/workloadgroup_types.go
+++ b/pkg/networking/v1alpha3/workloadgroup_types.go
@@ -85,7 +85,7 @@ type WorkloadGroupSpec struct {
 	// should default to `default`. The workload identities (mTLS certificates) will be bootstrapped using the
 	// specified service account's token. Workload entries in this group will be in the same namespace as the
 	// workload group, and inherit the labels and annotations from the above `metadata` field.
-	Template *WorkloadEntry `json:"template"`
+	Template *WorkloadEntrySpec `json:"template"`
 	// `ReadinessProbe` describes the configuration the user must provide for health-checking on their workload.
 	// This configuration mirrors K8S in both syntax and logic for the most part.
 	Probe *ReadinessProbe `json:"probe,omitempty"`

--- a/pkg/networking/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/networking/v1alpha3/zz_generated.deepcopy.go
@@ -2477,7 +2477,7 @@ func (in *WorkloadGroupSpec) DeepCopyInto(out *WorkloadGroupSpec) {
 	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
-		*out = new(WorkloadEntry)
+		*out = new(WorkloadEntrySpec)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Probe != nil {


### PR DESCRIPTION
### What's in this PR?
- redirect the mapping to the `WorkloadEntrySpec` struct which doesn't contain `metadata` and `objectmeta` field

It was previously mapped to
```
type WorkloadGroup struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata,omitempty"`
	Spec              WorkloadGroupSpec `json:"spec"`
}
```